### PR TITLE
explicity interpolate the name

### DIFF
--- a/_css3.scss
+++ b/_css3.scss
@@ -211,13 +211,13 @@
  * @group css3
  */
 @mixin keyframes($name) {
-    @-webkit-keyframes $name {
+    @-webkit-keyframes #{$name} {
         @content;
     }
-    @-moz-keyframes $name {
+    @-moz-keyframes #{$name} {
         @content;
     }
-    @keyframes $name {
+    @keyframes #{$name} {
         @content;
     }
 }


### PR DESCRIPTION
in sass 3.4, this scss:

``` scss
@include keyframesNew('myanimation') {
    0% {
        opacity: 1;
    }
    100% {
        opacity: 0;
    }
}
```

with the non-interpolated variable name results in: 

``` css
@keyframes $name {
  0% {
    opacity: 0;
  }
  100% {
    opacity: 0;
  }
}
etc
```

In 3.3 and 3.4, interpolating results in:

``` css
@keyframes myanimation {
  0% {
    opacity: 1;
  }
  100% {
    opacity: 0;
  }
}
etc
```

for a live example, toggle the sass version at http://sassmeister.com/gist/c5640aa83a2622881bd5
